### PR TITLE
Fix unused import in load_data.py

### DIFF
--- a/src/olympoly/load_data.py
+++ b/src/olympoly/load_data.py
@@ -1,4 +1,3 @@
-from urllib import response
 from datasets import load_dataset
 import os
 from dotenv import load_dotenv


### PR DESCRIPTION
Closes #19

Removed unused `from urllib import response` import from load_data.py.

This import was not used and could shadow the `response` variable created from requests.get().