### PR TITLE
Fix load_data import in performance module

### DIFF
--- a/src/olympoly/load_data.py
+++ b/src/olympoly/load_data.py
@@ -49,6 +49,12 @@ def load_demographic_data():
 
     return df
 
+def load_data():
+    """
+    Wrapper function for compatibility with other modules.
+    """
+    return load_olympic_data()
+
 if __name__ == "__main__":
     data = load_demographic_data()
     print(data.head(10))


### PR DESCRIPTION
Fixes import error where performance.py expected load_data but only load_olympic_data existed.

Added a wrapper function load_data() for compatibility.
