### PR TITLE
Add market_vs_model module and tests

### DIFF
--- a/src/olympoly/olympics_betting/market_vs_model.py
+++ b/src/olympoly/olympics_betting/market_vs_model.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+
+def compare_market_vs_model(df_market, df_model, market_col="event", model_col="event"):
+    """
+    Compare market probabilities with model predictions.
+
+    Parameters:
+        df_market (pd.DataFrame):
+            Must contain columns ['event', 'price']
+
+        df_model (pd.DataFrame):
+            Must contain columns ['event' or other identifier, 'model_prob']
+
+        market_col (str):
+            Column name in df_market to merge on (default: "event")
+
+        model_col (str):
+            Column name in df_model to merge on (default: "event")
+
+    Returns:
+        pd.DataFrame with comparison and differences
+    """
+
+    # Rename market column for clarity
+    market = df_market.copy().rename(columns={"price": "market_prob"})
+
+    # Merge using flexible column names
+    merged = pd.merge(
+        market,
+        df_model,
+        left_on=market_col,
+        right_on=model_col,
+        how="inner"
+    )
+
+    # Compute disagreement
+    merged["difference"] = merged["market_prob"] - merged["model_prob"]
+
+    # Sort by biggest disagreement
+    merged = merged.sort_values(by="difference", key=abs, ascending=False)
+
+    return merged

--- a/tests/test_market_vs_model.py
+++ b/tests/test_market_vs_model.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+
+from olympoly.olympics_betting.market_vs_model import compare_market_vs_model
+
+
+def test_compare_market_vs_model_basic():
+    # Create fake market data
+    df_market = pd.DataFrame({
+        "event": ["USA", "China"],
+        "price": [0.7, 0.4]
+    })
+
+    # Create fake model data
+    df_model = pd.DataFrame({
+        "event": ["USA", "China"],
+        "model_prob": [0.6, 0.5]
+    })
+
+    result = compare_market_vs_model(df_market, df_model)
+
+    # Check columns exist
+    assert "market_prob" in result.columns
+    assert "model_prob" in result.columns
+    assert "difference" in result.columns
+
+    # Check calculation is correct
+    usa_row = result[result["event"] == "USA"].iloc[0]
+    assert pytest.approx(usa_row["difference"]) == 0.7 - 0.6
+
+
+def test_custom_column_names():
+    # Test flexibility when model uses a different column name (e.g., NOC instead of event)
+    df_market = pd.DataFrame({
+        "event": ["USA"],
+        "price": [0.7]
+    })
+
+    df_model = pd.DataFrame({
+        "NOC": ["USA"],
+        "model_prob": [0.6]
+    })
+
+    result = compare_market_vs_model(df_market, df_model, model_col="NOC")
+
+    assert not result.empty


### PR DESCRIPTION
Implements a new module to compare market probabilities with model predictions.

* Adds `compare_market_vs_model` function to merge and compute differences between market and model outputs
* Supports flexible column matching (e.g., event vs NOC)
* Adds corresponding pytest tests to validate functionality

